### PR TITLE
Add integration wrappers for tests

### DIFF
--- a/colab_gguf_nkat_integration.py
+++ b/colab_gguf_nkat_integration.py
@@ -1,0 +1,12 @@
+"""Wrapper to import Colab integration helpers from ``scripts`` directory."""
+
+import os
+import sys
+
+_base_dir = os.path.dirname(__file__)
+project_root = _base_dir
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from scripts.colab_gguf_nkat_integration import *  # noqa: F401,F403
+

--- a/gguf_nkat_integration.py
+++ b/gguf_nkat_integration.py
@@ -1,0 +1,13 @@
+"""Thin wrapper to import integration tools from the ``scripts`` directory."""
+
+import os
+import sys
+
+# Allow importing ``scripts`` when running tests from the ``tests`` directory.
+_base_dir = os.path.dirname(__file__)
+project_root = _base_dir
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from scripts.gguf_nkat_integration import *  # noqa: F401,F403
+

--- a/tests/colab_gguf_nkat_integration.py
+++ b/tests/colab_gguf_nkat_integration.py
@@ -1,0 +1,11 @@
+"""Test wrapper for importing Colab helper from project scripts."""
+
+import os
+import sys
+
+_base_dir = os.path.dirname(os.path.dirname(__file__))
+if _base_dir not in sys.path:
+    sys.path.insert(0, _base_dir)
+
+from scripts.colab_gguf_nkat_integration import *  # noqa: F401,F403
+

--- a/tests/gguf_nkat_integration.py
+++ b/tests/gguf_nkat_integration.py
@@ -1,0 +1,11 @@
+"""Local wrapper for importing the project module during test runs."""
+
+import os
+import sys
+
+_base_dir = os.path.dirname(os.path.dirname(__file__))
+if _base_dir not in sys.path:
+    sys.path.insert(0, _base_dir)
+
+from scripts.gguf_nkat_integration import *  # noqa: F401,F403
+


### PR DESCRIPTION
## Summary
- add lightweight wrapper modules for gguf_nkat integration
- update tests to import integration helpers correctly
- adjust imports to work from test directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5e002cf48325840cf89fca4714ad